### PR TITLE
Fix dark mode text box visibility issue

### DIFF
--- a/src/renderer/styles.css
+++ b/src/renderer/styles.css
@@ -1160,4 +1160,120 @@
     marker-start: url(#trace-connector-arrow);
     marker-end: url(#trace-connector-arrow);
   }
+
+  /* ConversionModal カードID設定フィールド */
+  .conversion-modal__card-id-settings {
+    @apply flex flex-col gap-3;
+  }
+
+  .conversion-modal__field-row {
+    @apply grid grid-cols-3 gap-3;
+  }
+
+  .conversion-modal__field {
+    @apply flex flex-col gap-1;
+  }
+
+  .conversion-modal__field label {
+    @apply text-xs font-semibold text-slate-600 dark:text-slate-300;
+  }
+
+  .conversion-modal__field input[type="text"],
+  .conversion-modal__field input[type="number"] {
+    @apply rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400;
+  }
+
+  .conversion-modal__field-help {
+    @apply text-xs text-slate-500 dark:text-slate-400;
+  }
+
+  .conversion-modal__radio-group {
+    @apply flex flex-wrap gap-3;
+  }
+
+  .conversion-modal__radio-inline {
+    @apply flex items-center gap-2 text-sm text-slate-700 dark:text-slate-200;
+  }
+
+  .conversion-modal__radio-inline input[type="radio"] {
+    @apply text-blue-500;
+  }
+
+  .conversion-modal__preview-box {
+    @apply mt-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200;
+  }
+
+  /* モーダルダイアログ（一括編集用） */
+  .modal-overlay {
+    @apply fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70 backdrop-blur-sm;
+  }
+
+  .modal-content {
+    @apply flex w-[480px] max-w-[calc(100%-2rem)] flex-col gap-4 rounded-2xl border border-slate-200 bg-white p-6 shadow-2xl dark:border-slate-700 dark:bg-slate-900;
+  }
+
+  .modal-title {
+    @apply text-lg font-semibold text-slate-800 dark:text-slate-100;
+  }
+
+  .modal-description {
+    @apply text-sm text-slate-600 dark:text-slate-300;
+  }
+
+  .modal-form {
+    @apply flex flex-col gap-3;
+  }
+
+  .modal-label {
+    @apply flex flex-col gap-1 text-xs font-semibold text-slate-600 dark:text-slate-300;
+  }
+
+  .modal-input {
+    @apply rounded-md border border-slate-300 bg-white px-3 py-2 text-sm text-slate-800 shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400;
+  }
+
+  .modal-actions {
+    @apply flex justify-end gap-2;
+  }
+
+  .modal-button {
+    @apply rounded-md px-4 py-2 text-sm font-semibold transition-colors;
+  }
+
+  .modal-button--primary {
+    @apply bg-blue-600 text-white hover:bg-blue-500 dark:bg-blue-500 dark:hover:bg-blue-400;
+  }
+
+  .modal-button--secondary {
+    @apply border border-slate-300 bg-white text-slate-700 hover:bg-slate-100 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:hover:bg-slate-700;
+  }
+
+  /* カードID編集 */
+  .card__card-id-edit-container {
+    @apply inline-flex items-center gap-1;
+  }
+
+  .card__card-id-input {
+    @apply rounded-md border border-slate-300 bg-white px-2 py-0.5 text-xs font-mono text-slate-800 shadow-sm focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-100 dark:placeholder:text-slate-400;
+  }
+
+  .card__card-id-input--error {
+    @apply border-rose-500 dark:border-rose-400;
+  }
+
+  .card__card-id-error {
+    @apply text-rose-500 dark:text-rose-400;
+  }
+
+  .card__card-id {
+    @apply text-xs font-mono text-slate-600 dark:text-slate-300;
+  }
+
+  .card__card-id--editable {
+    @apply cursor-pointer rounded-md px-1 transition-colors hover:bg-slate-200 dark:hover:bg-slate-700;
+  }
+
+  .card__card-id--empty {
+    @apply text-slate-400 dark:text-slate-500;
+  }
 }


### PR DESCRIPTION
[変更点詳細]
## ダークモード対応スタイルの追加
- カードID設定・編集用のテキストボックスにダークモード時の背景色・文字色を設定
- モーダルダイアログの入力フィールドにダークモード対応を追加
- 影響範囲：ConversionModal、CardPanel のカードID関連入力欄
- file: src/renderer/styles.css

変更内容：
- ダークモード時：背景色 slate-800、文字色 slate-100 を設定
- ライトモード時：背景色 white、文字色 slate-800 を維持
- これにより、ダークモード時に白背景・白文字で見づらかった問題を解決

LLM-Coauthored-By: claude-sonnet-4-5 @ Anthropic
LLM-Model: claude-sonnet-4-5-20250929